### PR TITLE
DateTimeFormatterConverter.isSourceTypeCompatible replaces sourceType…

### DIFF
--- a/src/main/java/walkingkooka/convert/DateTimeFormatterConverter.java
+++ b/src/main/java/walkingkooka/convert/DateTimeFormatterConverter.java
@@ -44,9 +44,14 @@ abstract class DateTimeFormatterConverter<S, D> extends Converter2 {
     public final boolean canConvert(final Object value,
                                     final Class<?> type,
                                     final ConverterContext context) {
-        return this.sourceType().isInstance(value) &&
+        return this.isSourceTypeCompatible(value) &&
                 this.targetType() == type;
     }
+
+    /**
+     * Performs an instanceof test. This is necessary to avoid calling {@link Class#isInstance(Object)}.
+     */
+    abstract boolean isSourceTypeCompatible(final Object value);
 
     abstract Class<S> sourceType();
 

--- a/src/main/java/walkingkooka/convert/DateTimeFormatterConverterLocalDateString.java
+++ b/src/main/java/walkingkooka/convert/DateTimeFormatterConverterLocalDateString.java
@@ -37,6 +37,11 @@ final class DateTimeFormatterConverterLocalDateString extends DateTimeFormatterC
     }
 
     @Override
+    boolean isSourceTypeCompatible(final Object value) {
+        return value instanceof LocalDate;
+    }
+
+    @Override
     Class<LocalDate> sourceType() {
         return LocalDate.class;
     }

--- a/src/main/java/walkingkooka/convert/DateTimeFormatterConverterLocalDateTimeString.java
+++ b/src/main/java/walkingkooka/convert/DateTimeFormatterConverterLocalDateTimeString.java
@@ -37,6 +37,11 @@ final class DateTimeFormatterConverterLocalDateTimeString extends DateTimeFormat
     }
 
     @Override
+    boolean isSourceTypeCompatible(final Object value) {
+        return value instanceof LocalDateTime;
+    }
+
+    @Override
     Class<LocalDateTime> sourceType() {
         return LocalDateTime.class;
     }

--- a/src/main/java/walkingkooka/convert/DateTimeFormatterConverterLocalTimeString.java
+++ b/src/main/java/walkingkooka/convert/DateTimeFormatterConverterLocalTimeString.java
@@ -37,6 +37,11 @@ final class DateTimeFormatterConverterLocalTimeString extends DateTimeFormatterC
     }
 
     @Override
+    boolean isSourceTypeCompatible(final Object value) {
+        return value instanceof LocalTime;
+    }
+
+    @Override
     Class<LocalTime> sourceType() {
         return LocalTime.class;
     }

--- a/src/main/java/walkingkooka/convert/DateTimeFormatterConverterStringLocalDate.java
+++ b/src/main/java/walkingkooka/convert/DateTimeFormatterConverterStringLocalDate.java
@@ -20,6 +20,7 @@ package walkingkooka.convert;
 import walkingkooka.datetime.DateTimeContext;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -39,6 +40,11 @@ final class DateTimeFormatterConverterStringLocalDate extends DateTimeFormatterC
      */
     private DateTimeFormatterConverterStringLocalDate(final Function<DateTimeContext, DateTimeFormatter> formatter) {
         super(formatter);
+    }
+
+    @Override
+    boolean isSourceTypeCompatible(final Object value) {
+        return value instanceof String;
     }
 
     @Override

--- a/src/main/java/walkingkooka/convert/DateTimeFormatterConverterStringLocalDateTime.java
+++ b/src/main/java/walkingkooka/convert/DateTimeFormatterConverterStringLocalDateTime.java
@@ -42,6 +42,11 @@ final class DateTimeFormatterConverterStringLocalDateTime extends DateTimeFormat
     }
 
     @Override
+    boolean isSourceTypeCompatible(final Object value) {
+        return value instanceof String;
+    }
+
+    @Override
     Class<String> sourceType() {
         return String.class;
     }

--- a/src/main/java/walkingkooka/convert/DateTimeFormatterConverterStringLocalTime.java
+++ b/src/main/java/walkingkooka/convert/DateTimeFormatterConverterStringLocalTime.java
@@ -41,6 +41,11 @@ final class DateTimeFormatterConverterStringLocalTime extends DateTimeFormatterC
     }
 
     @Override
+    boolean isSourceTypeCompatible(final Object value) {
+        return value instanceof String;
+    }
+
+    @Override
     Class<String> sourceType() {
         return String.class;
     }


### PR DESCRIPTION
….isInstance

- Necessary because Class.isInstance is not supported in J2CL.