### PR TITLE
ConverterTemporal.isSourceTypeCompatible

### DIFF
--- a/src/main/java/walkingkooka/convert/ConverterTemporal.java
+++ b/src/main/java/walkingkooka/convert/ConverterTemporal.java
@@ -34,8 +34,13 @@ abstract class ConverterTemporal<S, D> extends Converter2 {
     public final boolean canConvert(final Object value,
                                     final Class<?> type,
                                     final ConverterContext context) {
-        return this.sourceType().isInstance(value) && this.isTargetType(type);
+        return this.isSourceTypeCompatible(value) && this.isTargetType(type);
     }
+
+    /**
+     * Performs an instanceof test. This is necessary to avoid calling {@link Class#isInstance(Object)}.
+     */
+    abstract boolean isSourceTypeCompatible(final Object value);
 
     abstract boolean isTargetType(final Class<?> type);
 

--- a/src/main/java/walkingkooka/convert/ConverterTemporalLocalDate.java
+++ b/src/main/java/walkingkooka/convert/ConverterTemporalLocalDate.java
@@ -32,6 +32,11 @@ abstract class ConverterTemporalLocalDate<D> extends ConverterTemporal<LocalDate
     }
 
     @Override
+    final boolean isSourceTypeCompatible(final Object value) {
+        return value instanceof LocalDate;
+    }
+
+    @Override
     final Class<LocalDate> sourceType() {
         return LocalDate.class;
     }

--- a/src/main/java/walkingkooka/convert/ConverterTemporalLocalDateTime.java
+++ b/src/main/java/walkingkooka/convert/ConverterTemporalLocalDateTime.java
@@ -19,6 +19,7 @@ package walkingkooka.convert;
 
 import walkingkooka.Either;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 /**
@@ -31,6 +32,11 @@ abstract class ConverterTemporalLocalDateTime<D> extends ConverterTemporal<Local
      */
     ConverterTemporalLocalDateTime(final long offset) {
         super(offset);
+    }
+
+    @Override
+    final boolean isSourceTypeCompatible(final Object value) {
+        return value instanceof LocalDateTime;
     }
 
     @Override


### PR DESCRIPTION
- Necessary because Class.isInstance is not supported by J2CL.