### PR TITLE
Converter.failConversion Throwable null/empty skip

### DIFF
--- a/src/main/java/walkingkooka/convert/Converter.java
+++ b/src/main/java/walkingkooka/convert/Converter.java
@@ -69,7 +69,10 @@ public interface Converter {
     default <T> Either<T, String> failConversion(final Object value,
                                                  final Class<T> target,
                                                  final Throwable cause) {
-        return Either.right("Failed to convert " + CharSequences.quoteIfChars(value) + " (" + value.getClass().getName() + ") to " + target.getName() + " " + cause.getMessage());
+        final String message = cause.getMessage();
+        return CharSequences.isNullOrEmpty(message) ?
+                failConversion(value, target) :
+                Either.right("Failed to convert " + CharSequences.quoteIfChars(value) + " (" + value.getClass().getName() + ") to " + target.getName() + ", " + cause.getMessage());
     }
 
     /**

--- a/src/test/java/walkingkooka/convert/ConverterTest.java
+++ b/src/test/java/walkingkooka/convert/ConverterTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.convert;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.Either;
+import walkingkooka.reflect.ClassTesting;
+import walkingkooka.reflect.JavaVisibility;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public final class ConverterTest implements ClassTesting<Converter> {
+
+    @Test
+    public void testFailConversion() {
+        assertEquals(Either.right("Failed to convert 1 (java.lang.Integer) to java.lang.String"), new FakeConverter().failConversion(1, String.class));
+    }
+
+    @Test
+    public void testFailConversionNullMessage() {
+        assertEquals(Either.right("Failed to convert 1 (java.lang.Integer) to java.lang.String"), new FakeConverter().failConversion(1, String.class, new NullPointerException()));
+    }
+
+    @Test
+    public void testFailConversionEmptyMessage() {
+        assertEquals(Either.right("Failed to convert 1 (java.lang.Integer) to java.lang.String"), new FakeConverter().failConversion(1, String.class, new NullPointerException("")));
+    }
+
+    @Test
+    public void testFailConversionMessage() {
+        assertEquals(Either.right("Failed to convert 1 (java.lang.Integer) to java.lang.String, Exception message"), new FakeConverter().failConversion(1, String.class, new NullPointerException("Exception message")));
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PUBLIC;
+    }
+
+    @Override
+    public Class<Converter> type() {
+        return Converter.class;
+    }
+}


### PR DESCRIPTION
- Previously null was concat on the end of the message, this is now ignored.