### PR TITLE
Converters.customToString converter parameter missing type parameter fix

### DIFF
--- a/src/main/java/walkingkooka/convert/Converters.java
+++ b/src/main/java/walkingkooka/convert/Converters.java
@@ -129,7 +129,8 @@ public final class Converters implements PublicStaticHelper {
     /**
      * {@see CustomToStringConverter}
      */
-    public static <C extends ConverterContext> Converter<C> customToString(final Converter converter, final String toString) {
+    public static <C extends ConverterContext> Converter<C> customToString(final Converter<C> converter,
+                                                                           final String toString) {
         return CustomToStringConverter.wrap(converter, toString);
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-convert/issues/62
- Converters.customToString Converter parameter missing type parameter