### PR TITLE
Converters.function missing ConverterContext type parameter fix

### DIFF
--- a/src/main/java/walkingkooka/convert/Converters.java
+++ b/src/main/java/walkingkooka/convert/Converters.java
@@ -146,9 +146,9 @@ public final class Converters implements PublicStaticHelper {
     /**
      * [@see FunctionConverter}
      */
-    public static <S, D> Converter function(final Predicate<Object> source,
-                                            final Predicate<Class<?>> target,
-                                            final Function<S, D> converter) {
+    public static <S, D, C extends ConverterContext> Converter<C> function(final Predicate<Object> source,
+                                                                           final Predicate<Class<?>> target,
+                                                                           final Function<S, D> converter) {
         return FunctionConverter.with(source, target, converter);
     }
 

--- a/src/test/java/walkingkooka/convert/ConverterCollectionTest.java
+++ b/src/test/java/walkingkooka/convert/ConverterCollectionTest.java
@@ -98,7 +98,11 @@ public final class ConverterCollectionTest extends ConverterTestCase2<ConverterC
     }
 
     private Converter<ConverterContext> booleanToString() {
-        return Converters.<String, Boolean>function(t-> t instanceof String, Predicates.is(Boolean.class), Boolean::valueOf);
+        return Converters.<String, Boolean, ConverterContext>function(
+                t-> t instanceof String,
+                Predicates.is(Boolean.class),
+                Boolean::valueOf
+        );
     }
 
     @Override


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-convert/issues/61
- Converters.function return type Converter missing type parameter