### PR TITLE
CanConvert.convertThrowable(String)

### DIFF
--- a/src/main/java/walkingkooka/convert/CanConvert.java
+++ b/src/main/java/walkingkooka/convert/CanConvert.java
@@ -44,7 +44,7 @@ public interface CanConvert {
                                 final Class<T> target) {
         final Either<T, String> converted = this.convert(value, target);
         if (converted.isRight()) {
-            throw new ConversionException(converted.rightValue());
+            throw this.convertThrowable(converted.rightValue());
         }
 
         return converted.leftValue();
@@ -65,5 +65,12 @@ public interface CanConvert {
                                                  final Class<T> target,
                                                  final Throwable cause) {
         return FailConversion.handle(value, target, cause);
+    }
+
+    /**
+     * Creates a {@link Throwable} which may then be thrown to report a convert failure.
+     */
+    default RuntimeException convertThrowable(final String message) {
+        return new ConversionException(message);
     }
 }

--- a/src/test/java/walkingkooka/convert/CanConvertTestingTest.java
+++ b/src/test/java/walkingkooka/convert/CanConvertTestingTest.java
@@ -84,6 +84,35 @@ public final class CanConvertTestingTest {
     }
 
     @Test
+    public void testConvertOrFailCustomConvertThrowableFails() {
+        final String message = "message 123";
+        final RuntimeException thrown = assertThrows(RuntimeException.class,
+                () -> {
+                    new CanConvert() {
+
+                        @Override
+                        public boolean canConvert(final Object value,
+                                                  final Class<?> type) {
+                            return false;
+                        }
+
+                        @Override //
+                        public <T> Either<T, String> convert(final Object value,
+                                                             final Class<T> target) {
+                            return Either.right(message);
+                        }
+
+                        @Override
+                        public RuntimeException convertThrowable(final String message) {
+                            return new RuntimeException(message);
+                        }
+                    }.convertOrFail(this, this.getClass());
+                });
+
+        assertEquals(message, thrown.getMessage(), "message");
+    }
+
+    @Test
     public void testConvertOrFailDoesntThrows() {
         this.create(true, Either.left(CONVERTED));
     }


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-convert/issues/72
- Introduce CanConvert.convertFailed(String) and String, Throwable used to throw