### PR TITLE
ConverterNumberNumber bounds tests replace convert & equality

### DIFF
--- a/src/main/java/walkingkooka/convert/ConverterNumberNumber.java
+++ b/src/main/java/walkingkooka/convert/ConverterNumberNumber.java
@@ -23,6 +23,8 @@ import walkingkooka.math.Maths;
 
 /**
  * A {@link Converter} which handles converting {@link Number} to other number types or nothing at all if the target is number.
+ * Note attempts to convert out of range values that is too small or too large will fail, however conversions that result in precision being lost
+ * will succeed, eg a decimal float such as 2.5 will be converted to integer 2.
  */
 final class ConverterNumberNumber<C extends ConverterContext> extends Converter2<C> {
 

--- a/src/main/java/walkingkooka/convert/ConverterNumberNumberNumberTypeVisitorByte.java
+++ b/src/main/java/walkingkooka/convert/ConverterNumberNumberNumberTypeVisitorByte.java
@@ -35,7 +35,7 @@ final class ConverterNumberNumberNumberTypeVisitorByte extends ConverterNumberNu
         this.save(number.byteValueExact());
     }
 
-    @Override 
+    @Override
     protected void visit(final BigInteger number) {
         this.save(number.byteValueExact());
     }
@@ -47,41 +47,46 @@ final class ConverterNumberNumberNumberTypeVisitorByte extends ConverterNumberNu
 
     @Override
     protected void visit(final Double number) {
-        final byte converted = number.byteValue();
-        if (converted == number) {
-            this.save(converted);
+        if (number >= Byte.MIN_VALUE && number <= Byte.MAX_VALUE) {
+            this.save(
+                    number.byteValue()
+            );
         }
     }
 
-    @Override 
+    @Override
     protected void visit(final Float number) {
-        final byte converted = number.byteValue();
-        if (converted == number) {
-            this.save(converted);
+        if (number >= Byte.MIN_VALUE && number <= Byte.MAX_VALUE) {
+            this.save(
+                    number.byteValue()
+            );
         }
     }
 
-    @Override 
+    @Override
     protected void visit(final Integer number) {
-        final byte converted = number.byteValue();
-        if (converted == number) {
-            this.save(converted);
+        if (number >= Byte.MIN_VALUE && number <= Byte.MAX_VALUE) {
+            this.save(
+                    number.byteValue()
+            );
         }
     }
 
-    @Override 
+    @Override
     protected void visit(final Long number) {
-        final byte converted = number.byteValue();
-        if (converted == number) {
-            this.save(converted);
+        if (number >= Byte.MIN_VALUE && number <= Byte.MAX_VALUE) {
+            this.save(
+                    number.byteValue()
+            );
         }
     }
 
-    @Override 
+    @Override
     protected void visit(final Short number) {
-        final byte converted = number.byteValue();
-        if (converted == number) {
-            this.save(converted);
+        if (number >= Byte.MIN_VALUE && number <= Byte.MAX_VALUE) {
+            this.save(
+                    number.byteValue()
+            );
         }
     }
 

--- a/src/main/java/walkingkooka/convert/ConverterNumberNumberNumberTypeVisitorDouble.java
+++ b/src/main/java/walkingkooka/convert/ConverterNumberNumberNumberTypeVisitorDouble.java
@@ -32,19 +32,29 @@ final class ConverterNumberNumberNumberTypeVisitorDouble extends ConverterNumber
 
     @Override
     protected void visit(final BigDecimal number) {
-        final double converted = number.doubleValue();
-        if (0 == new BigDecimal(converted).compareTo(number)) {
-            this.save(converted);
+        if (number.compareTo(BIG_DECIMAL_DOUBLE_MIN) >= 0 && number.compareTo(BIG_DECIMAL_DOUBLE_MAX) <= 0) {
+            this.save(
+                    number.doubleValue()
+            );
         }
     }
 
-    @Override 
+    private final static BigDecimal BIG_DECIMAL_DOUBLE_MIN = BigDecimal.valueOf(-Double.MAX_VALUE);
+
+    private final static BigDecimal BIG_DECIMAL_DOUBLE_MAX = BigDecimal.valueOf(Double.MAX_VALUE);
+
+    @Override
     protected void visit(final BigInteger number) {
-        final double converted = number.doubleValue();
-        if (new BigDecimal(converted).toBigInteger().equals(number)) {
-            this.save(converted);
+        if (number.compareTo(BIG_INTEGER_DOUBLE_MIN) >= 0 && number.compareTo(BIG_INTEGER_DOUBLE_MAX) <= 0) {
+            this.save(
+                    number.doubleValue()
+            );
         }
     }
+
+    private final static BigInteger BIG_INTEGER_DOUBLE_MIN = BIG_DECIMAL_DOUBLE_MIN.toBigInteger();
+
+    private final static BigInteger BIG_INTEGER_DOUBLE_MAX = BIG_DECIMAL_DOUBLE_MAX.toBigInteger();
 
     @Override
     protected void visit(final Byte number) {
@@ -56,25 +66,25 @@ final class ConverterNumberNumberNumberTypeVisitorDouble extends ConverterNumber
         this.save(number);
     }
 
-    @Override 
+    @Override
     protected void visit(final Float number) {
         this.saveDouble(number);
     }
 
-    @Override 
+    @Override
     protected void visit(final Integer number) {
         this.saveDouble(number);
     }
 
-    @Override 
+    @Override
     protected void visit(final Long number) {
         final double converted = number.doubleValue();
-        if ((long)converted == number) {
+        if ((long) converted == number) {
             this.save(converted);
         }
     }
 
-    @Override 
+    @Override
     protected void visit(final Short number) {
         this.saveDouble(number);
     }

--- a/src/main/java/walkingkooka/convert/ConverterNumberNumberNumberTypeVisitorFloat.java
+++ b/src/main/java/walkingkooka/convert/ConverterNumberNumberNumberTypeVisitorFloat.java
@@ -32,19 +32,29 @@ final class ConverterNumberNumberNumberTypeVisitorFloat extends ConverterNumberN
 
     @Override
     protected void visit(final BigDecimal number) {
-        final float converted = number.floatValue();
-        if (0 == new BigDecimal(converted).compareTo(number)) {
-            this.save(converted);
+        if (number.compareTo(BIG_DECIMAL_DOUBLE_MIN) >= 0 && number.compareTo(BIG_DECIMAL_DOUBLE_MAX) <= 0) {
+            this.save(
+                    number.floatValue()
+            );
         }
     }
 
+    private final static BigDecimal BIG_DECIMAL_DOUBLE_MIN = BigDecimal.valueOf(-Float.MAX_VALUE);
+
+    private final static BigDecimal BIG_DECIMAL_DOUBLE_MAX = BigDecimal.valueOf(Float.MAX_VALUE);
+
     @Override
     protected void visit(final BigInteger number) {
-        final float converted = number.floatValue();
-        if (new BigDecimal(converted).toBigIntegerExact().equals(number)) {
-            this.save(converted);
+        if (number.compareTo(BIG_INTEGER_DOUBLE_MIN) >= 0 && number.compareTo(BIG_INTEGER_DOUBLE_MAX) <= 0) {
+            this.save(
+                    number.floatValue()
+            );
         }
     }
+
+    private final static BigInteger BIG_INTEGER_DOUBLE_MIN = BIG_DECIMAL_DOUBLE_MIN.toBigInteger();
+
+    private final static BigInteger BIG_INTEGER_DOUBLE_MAX = BIG_DECIMAL_DOUBLE_MAX.toBigInteger();
 
     @Override
     protected void visit(final Byte number) {
@@ -53,18 +63,19 @@ final class ConverterNumberNumberNumberTypeVisitorFloat extends ConverterNumberN
 
     @Override
     protected void visit(final Double number) {
-        final float converted = number.floatValue();
-        if (converted == number) {
-            this.save(converted);
+        if (number >= -Float.MAX_VALUE && number <= Float.MAX_VALUE) {
+            this.save(
+                    number.floatValue()
+            );
         }
     }
 
-    @Override 
+    @Override
     protected void visit(final Float number) {
         this.save(number);// dead code because Float to Float is short circuited earlier by ConverterNumberNumber.
     }
 
-    @Override 
+    @Override
     protected void visit(final Integer number) {
         this.saveFloat(number);
     }
@@ -72,13 +83,10 @@ final class ConverterNumberNumberNumberTypeVisitorFloat extends ConverterNumberN
     @SuppressWarnings("UnnecessaryUnboxing")
     @Override
     protected void visit(final Long number) {
-        final float converted = number.floatValue();
-        if (Float.valueOf(converted).longValue() == number.longValue()) {
-            this.save(converted);
-        }
+        this.save(number.floatValue()); // ??? not sure if precision lost should matter
     }
 
-    @Override 
+    @Override
     protected void visit(final Short number) {
         this.saveFloat(number);
     }

--- a/src/main/java/walkingkooka/convert/ConverterNumberNumberNumberTypeVisitorInteger.java
+++ b/src/main/java/walkingkooka/convert/ConverterNumberNumberNumberTypeVisitorInteger.java
@@ -35,52 +35,55 @@ final class ConverterNumberNumberNumberTypeVisitorInteger extends ConverterNumbe
         this.save(number.intValueExact());
     }
 
-    @Override 
+    @Override
     protected void visit(final BigInteger number) {
         this.save(number.intValueExact());
     }
 
     @Override
     protected void visit(final Byte number) {
-        this.saveInteger(number);
+        this.save(number.intValue());
     }
 
     @Override
     protected void visit(final Double number) {
-        final int converted = number.intValue();
-        if (converted == number) {
-            this.save(converted);
+        if (number >= Integer.MIN_VALUE && number <= Integer.MAX_VALUE) {
+            this.save(
+                    number.intValue()
+            );
         }
     }
 
-    @Override 
+    @Override
     protected void visit(final Float number) {
-        final int converted = number.intValue();
-        if (converted == number) {
-            this.save(converted);
+        if (number >= Integer.MIN_VALUE && number <= Integer.MAX_VALUE) {
+            this.save(
+                    number.intValue()
+            );
         }
     }
 
-    @Override 
+    @Override
     protected void visit(final Integer number) {
         this.save(number);
     }
 
-    @Override 
+    @Override
     protected void visit(final Long number) {
-        final int converted = number.intValue();
-        if (converted == number) {
-            this.save(converted);
+        if (number >= Integer.MIN_VALUE && number <= Integer.MAX_VALUE) {
+            this.save(
+                    number.intValue()
+            );
         }
     }
 
-    @Override 
+    @Override
     protected void visit(final Short number) {
-        this.saveInteger(number);
-    }
-
-    private void saveInteger(final Number number) {
-        this.save(number.intValue());
+        if (number >= Integer.MIN_VALUE && number <= Integer.MAX_VALUE) {
+            this.save(
+                    number.intValue()
+            );
+        }
     }
 
     @Override

--- a/src/main/java/walkingkooka/convert/ConverterNumberNumberNumberTypeVisitorLong.java
+++ b/src/main/java/walkingkooka/convert/ConverterNumberNumberNumberTypeVisitorLong.java
@@ -35,7 +35,7 @@ final class ConverterNumberNumberNumberTypeVisitorLong extends ConverterNumberNu
         this.save(number.longValueExact());
     }
 
-    @Override 
+    @Override
     protected void visit(final BigInteger number) {
         this.save(number.longValueExact());
     }
@@ -47,25 +47,33 @@ final class ConverterNumberNumberNumberTypeVisitorLong extends ConverterNumberNu
 
     @Override
     protected void visit(final Double number) {
-        this.visit(new BigDecimal(number));
+        if (number >= Long.MIN_VALUE && number <= Long.MAX_VALUE) {
+            this.save(
+                    number.longValue()
+            );
+        }
     }
 
-    @Override 
+    @Override
     protected void visit(final Float number) {
-        this.visit(new BigDecimal(number));
+        if (number >= Long.MIN_VALUE && number <= Long.MAX_VALUE) {
+            this.save(
+                    number.longValue()
+            );
+        }
     }
 
-    @Override 
+    @Override
     protected void visit(final Integer number) {
         this.save(number.longValue());
     }
 
-    @Override 
+    @Override
     protected void visit(final Long number) {
         this.save(number);
     }
 
-    @Override 
+    @Override
     protected void visit(final Short number) {
         this.saveLong(number);
     }

--- a/src/main/java/walkingkooka/convert/ConverterNumberNumberNumberTypeVisitorShort.java
+++ b/src/main/java/walkingkooka/convert/ConverterNumberNumberNumberTypeVisitorShort.java
@@ -35,7 +35,7 @@ final class ConverterNumberNumberNumberTypeVisitorShort extends ConverterNumberN
         this.save(number.shortValueExact());
     }
 
-    @Override 
+    @Override
     protected void visit(final BigInteger number) {
         this.save(number.shortValueExact());
     }
@@ -47,37 +47,41 @@ final class ConverterNumberNumberNumberTypeVisitorShort extends ConverterNumberN
 
     @Override
     protected void visit(final Double number) {
-        final short converted = number.shortValue();
-        if (converted == number) {
-            this.save(converted);
+        if (number >= Short.MIN_VALUE && number <= Short.MAX_VALUE) {
+            this.save(
+                    number.shortValue()
+            );
         }
     }
 
-    @Override 
+    @Override
     protected void visit(final Float number) {
-        final short converted = number.shortValue();
-        if (converted == number) {
-            this.save(converted);
+        if (number >= Short.MIN_VALUE && number <= Short.MAX_VALUE) {
+            this.save(
+                    number.shortValue()
+            );
         }
     }
 
-    @Override 
+    @Override
     protected void visit(final Integer number) {
-        final short converted = number.shortValue();
-        if (converted == number) {
-            this.save(converted);
+        if (number >= Short.MIN_VALUE && number <= Short.MAX_VALUE) {
+            this.save(
+                    number.shortValue()
+            );
         }
     }
 
-    @Override 
+    @Override
     protected void visit(final Long number) {
-        final short converted = number.shortValue();
-        if (converted == number) {
-            this.save(converted);
+        if (number >= Short.MIN_VALUE && number <= Short.MAX_VALUE) {
+            this.save(
+                    number.shortValue()
+            );
         }
     }
 
-    @Override 
+    @Override
     protected void visit(final Short number) {
         this.save(number);// dead code because Short to Short is short circuited earlier by ConverterNumberNumber.
     }

--- a/src/test/java/walkingkooka/convert/ConverterNumberNumberTest.java
+++ b/src/test/java/walkingkooka/convert/ConverterNumberNumberTest.java
@@ -251,13 +251,16 @@ public final class ConverterNumberNumberTest extends ConverterTestCase2<Converte
     }
 
     @Test
-    public void testDoubleToByteFails() {
-        this.convertToByteFails(Double.MAX_VALUE);
+    public void testDoubleToByteWithPrecisionLoss() {
+        this.convertToByteAndCheck(
+                1.5,
+                (byte)1
+        );
     }
 
     @Test
-    public void testDoubleToByteFails2() {
-        this.convertToByteFails(0.5);
+    public void testDoubleToByteFails() {
+        this.convertToByteFails(Double.MAX_VALUE);
     }
 
     @Test
@@ -266,13 +269,16 @@ public final class ConverterNumberNumberTest extends ConverterTestCase2<Converte
     }
 
     @Test
-    public void testFloatToByteFails() {
-        this.convertToByteFails(Float.MAX_VALUE);
+    public void testFloatToByteWithPrecisionLoss() {
+        this.convertToByteAndCheck(
+                1.5f,
+                (byte)1
+        );
     }
 
     @Test
-    public void testFloatToByteFails2() {
-        this.convertToByteFails(2.5f);
+    public void testFloatToByteFails() {
+        this.convertToByteFails(Float.MAX_VALUE);
     }
 
     @Test
@@ -306,7 +312,19 @@ public final class ConverterNumberNumberTest extends ConverterTestCase2<Converte
     }
 
     private void convertToByteAndCheck(final Number number) {
-        this.convertAndCheck(number, Byte.class, this.byteValue());
+        this.convertAndCheck(
+                number,
+                this.byteValue()
+        );
+    }
+
+    private void convertToByteAndCheck(final Number number,
+                                       final Byte expected) {
+        this.convertAndCheck(
+                number,
+                Byte.class,
+                expected
+        );
     }
 
     private void convertToByteFails(final Number number) {
@@ -372,8 +390,11 @@ public final class ConverterNumberNumberTest extends ConverterTestCase2<Converte
     }
 
     @Test
-    public void testBigIntegerToFloatFails() {
-        this.convertToFloatFails(this.bigIntegerLongMax2());
+    public void testBigIntegerToFloatWithPrecisionLoss() {
+        this.convertToFloatAndCheck(
+                this.bigIntegerLongMax2(),
+                8.507059E37f
+        );
     }
 
     @Test
@@ -402,7 +423,19 @@ public final class ConverterNumberNumberTest extends ConverterTestCase2<Converte
     }
 
     private void convertToFloatAndCheck(final Number number) {
-        this.convertAndCheck(number, Float.class, this.floatValue());
+        this.convertToFloatAndCheck(
+                number,
+                this.floatValue()
+        );
+    }
+
+    private void convertToFloatAndCheck(final Number number,
+                                        final Float expected) {
+        this.convertAndCheck(
+                number,
+                Float.class,
+                expected
+        );
     }
 
     private void convertToFloatFails(final Number number) {
@@ -452,8 +485,11 @@ public final class ConverterNumberNumberTest extends ConverterTestCase2<Converte
     }
 
     @Test
-    public void testDoubleToIntegerFails2() {
-        this.convertToIntegerFails(0.5);
+    public void testDoubleToIntegerWithPrecisionLoss() {
+        this.convertToIntegerAndCheck(
+                1.5,
+                1
+        );
     }
 
     @Test
@@ -467,8 +503,11 @@ public final class ConverterNumberNumberTest extends ConverterTestCase2<Converte
     }
 
     @Test
-    public void testFloatToIntegerFails2() {
-        this.convertToIntegerFails(2.5f);
+    public void testFloatToIntegerWithPrecisionLoss() {
+        this.convertToIntegerAndCheck(
+                2.5f,
+                2
+        );
     }
 
     @Test
@@ -487,7 +526,19 @@ public final class ConverterNumberNumberTest extends ConverterTestCase2<Converte
     }
 
     private void convertToIntegerAndCheck(final Number number) {
-        this.convertAndCheck(number, Integer.class, this.integerValue());
+        this.convertToIntegerAndCheck(
+                number,
+                this.integerValue()
+        );
+    }
+
+    private void convertToIntegerAndCheck(final Number number,
+                                          final Integer expected) {
+        this.convertAndCheck(
+                number,
+                Integer.class,
+                expected
+        );
     }
 
     private void convertToIntegerFails(final Number number) {
@@ -537,8 +588,11 @@ public final class ConverterNumberNumberTest extends ConverterTestCase2<Converte
     }
 
     @Test
-    public void testDoubleToLongFails2() {
-        this.convertToLongFails(0.5);
+    public void testDoubleToLongWithPrecisionLoss() {
+        this.convertToLongAndCheck(
+                1.5,
+                1L
+        );
     }
 
     @Test
@@ -552,8 +606,11 @@ public final class ConverterNumberNumberTest extends ConverterTestCase2<Converte
     }
 
     @Test
-    public void testFloatToLongFails2() {
-        this.convertToLongFails(2.5f);
+    public void testFloatToLongWithPrecisionLoss() {
+        this.convertToLongAndCheck(
+                2.5f,
+                2L
+        );
     }
 
     @Test
@@ -567,7 +624,19 @@ public final class ConverterNumberNumberTest extends ConverterTestCase2<Converte
     }
 
     private void convertToLongAndCheck(final Number number) {
-        this.convertAndCheck(number, Long.class, this.longValue());
+        this.convertToLongAndCheck(
+                number,
+                this.longValue()
+        );
+    }
+
+    private void convertToLongAndCheck(final Number number,
+                                       final long expected) {
+        this.convertAndCheck(
+                number,
+                Long.class,
+                expected
+        );
     }
 
     private void convertToLongFails(final Number number) {
@@ -617,8 +686,11 @@ public final class ConverterNumberNumberTest extends ConverterTestCase2<Converte
     }
 
     @Test
-    public void testDoubleToShortFails2() {
-        this.convertToShortFails(0.5);
+    public void testDoubleToShortWithPrecisionLoss() {
+        this.convertToShortAndCheck(
+                1.5,
+                (short)1
+        );
     }
 
     @Test
@@ -632,8 +704,11 @@ public final class ConverterNumberNumberTest extends ConverterTestCase2<Converte
     }
 
     @Test
-    public void testFloatToShortFails2() {
-        this.convertToShortFails(2.5f);
+    public void testFloatToShortWithPrecisionLoss() {
+        this.convertToShortAndCheck(
+                2.5f,
+                (short)2
+        );
     }
 
     @Test
@@ -657,7 +732,19 @@ public final class ConverterNumberNumberTest extends ConverterTestCase2<Converte
     }
 
     private void convertToShortAndCheck(final Number number) {
-        this.convertAndCheck(number, Short.class, this.shortValue());
+        this.convertToShortAndCheck(
+                number,
+                this.shortValue()
+        );
+    }
+
+    private void convertToShortAndCheck(final Number number,
+                                        final short expected) {
+        this.convertAndCheck(
+                number,
+                Short.class,
+                expected
+        );
     }
 
     private void convertToShortFails(final Number number) {


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-convert/issues/140
- ConverterNumberNumber precision loss tests can cause failure when only a few lower bits "change".