### PR TITLE
SimpleConverter.canConvert subclass of type support

### DIFF
--- a/src/main/java/walkingkooka/convert/SimpleConverter.java
+++ b/src/main/java/walkingkooka/convert/SimpleConverter.java
@@ -48,7 +48,33 @@ final class SimpleConverter<C extends ConverterContext> implements Converter<C> 
     public boolean canConvert(final Object value,
                               final Class<?> type,
                               final C context) {
-        return null == value || type == value.getClass();
+        return null == value ||
+                this.isSubClass(
+                        value,
+                        type
+                );
+    }
+
+    /**
+     * Because Class#isInstance is not supported by GWT, this is partially emulated and will match sub-classes but not
+     * interface implementations.
+     */
+    private boolean isSubClass(final Object value,
+                               final Class<?> superClass) {
+        boolean isSubClass;
+
+        Class<?> valueType = value.getClass();
+        do {
+            isSubClass = valueType == superClass;
+            if (isSubClass) {
+                break;
+            }
+
+            valueType = valueType.getSuperclass();
+
+        } while (null != valueType);
+
+        return isSubClass;
     }
 
     @Override

--- a/src/test/java/walkingkooka/convert/SimpleConverterTest.java
+++ b/src/test/java/walkingkooka/convert/SimpleConverterTest.java
@@ -21,6 +21,9 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
 import walkingkooka.ToStringTesting;
 
+import java.util.AbstractList;
+import java.util.ArrayList;
+
 public final class SimpleConverterTest extends ConverterTestCase<SimpleConverter<ConverterContext>>
         implements ConverterTesting2<SimpleConverter<ConverterContext>, ConverterContext>,
         ToStringTesting<SimpleConverter<ConverterContext>> {
@@ -38,6 +41,22 @@ public final class SimpleConverterTest extends ConverterTestCase<SimpleConverter
         this.convertAndCheck(
                 "ABC",
                 String.class
+        );
+    }
+
+    @Test
+    public void testConvertSubClass() {
+        this.convertAndCheck(
+                new ArrayList(),
+                AbstractList.class
+        );
+    }
+
+    @Test
+    public void testConvertSubClassObject() {
+        this.convertAndCheck(
+                this,
+                Object.class
         );
     }
 


### PR DESCRIPTION
- Uses Class#getSuperclass to test if a value is a subclass of type.