### PR TITLE
https://github.com/mP1/walkingkooka-datetime/pull/76 BasicDateTimeCon…

### DIFF
--- a/src/test/java/walkingkooka/convert/BasicConverterContextTest.java
+++ b/src/test/java/walkingkooka/convert/BasicConverterContextTest.java
@@ -20,12 +20,14 @@ package walkingkooka.convert;
 import org.junit.jupiter.api.Test;
 import walkingkooka.datetime.DateTimeContext;
 import walkingkooka.datetime.DateTimeContexts;
+import walkingkooka.datetime.DateTimeSymbols;
 import walkingkooka.math.DecimalNumberContext;
 import walkingkooka.math.DecimalNumberContexts;
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.reflect.JavaVisibility;
 
 import java.math.MathContext;
+import java.text.DateFormatSymbols;
 import java.time.LocalDateTime;
 import java.util.Locale;
 
@@ -115,8 +117,13 @@ public final class BasicConverterContextTest implements ClassTesting2<BasicConve
     }
 
     private DateTimeContext dateTimeContext() {
-        return DateTimeContexts.locale(
-                Locale.FRANCE,
+        final Locale locale = Locale.FRANCE;
+
+        return DateTimeContexts.basic(
+                DateTimeSymbols.fromDateFormatSymbols(
+                        new DateFormatSymbols(locale)
+                ),
+                locale,
                 1900,
                 20,
                 LocalDateTime::now

--- a/src/test/java/walkingkooka/convert/CanConvertDelegatorTest.java
+++ b/src/test/java/walkingkooka/convert/CanConvertDelegatorTest.java
@@ -20,9 +20,11 @@ package walkingkooka.convert;
 import org.junit.jupiter.api.Test;
 import walkingkooka.convert.CanConvertDelegatorTest.TestCanConvertDelegator;
 import walkingkooka.datetime.DateTimeContexts;
+import walkingkooka.datetime.DateTimeSymbols;
 import walkingkooka.math.DecimalNumberContexts;
 
 import java.math.MathContext;
+import java.text.DateFormatSymbols;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -51,13 +53,18 @@ public final class CanConvertDelegatorTest implements CanConvertTesting<TestCanC
     static class TestCanConvertDelegator implements CanConvertDelegator {
         @Override
         public CanConvert canConvert() {
+            final Locale locale = Locale.forLanguageTag("EN-AU");
+
             return ConverterContexts.basic(
                     Converters.EXCEL_1900_DATE_SYSTEM_OFFSET,
                     Converters.stringToLocalDate(
                             (x) -> DateTimeFormatter.ofPattern("yyyy MM dd")
                     ),
-                    DateTimeContexts.locale(
-                            Locale.forLanguageTag("EN-AU"),
+                    DateTimeContexts.basic(
+                            DateTimeSymbols.fromDateFormatSymbols(
+                                    new DateFormatSymbols(locale)
+                            ),
+                            locale,
                             1950, // defaultYear
                             50, // twoDigitYear
                             LocalDateTime::now

--- a/src/test/java/walkingkooka/convert/ConverterContextDelegatorTest.java
+++ b/src/test/java/walkingkooka/convert/ConverterContextDelegatorTest.java
@@ -19,9 +19,11 @@ package walkingkooka.convert;
 
 import walkingkooka.convert.ConverterContextDelegatorTest.TestConverterContextDelegator;
 import walkingkooka.datetime.DateTimeContexts;
+import walkingkooka.datetime.DateTimeSymbols;
 import walkingkooka.math.DecimalNumberContexts;
 
 import java.math.MathContext;
+import java.text.DateFormatSymbols;
 import java.time.LocalDateTime;
 import java.util.Locale;
 
@@ -96,11 +98,16 @@ public final class ConverterContextDelegatorTest implements ConverterContextTest
 
         @Override
         public ConverterContext converterContext() {
+            final Locale locale = Locale.ENGLISH;
+
             return ConverterContexts.basic(
                     0,
                     Converters.fake(),
-                    DateTimeContexts.locale(
-                            Locale.ENGLISH,
+                    DateTimeContexts.basic(
+                            DateTimeSymbols.fromDateFormatSymbols(
+                                    new DateFormatSymbols(locale)
+                            ),
+                            locale,
                             1900,
                             50,
                             LocalDateTime::now


### PR DESCRIPTION
…text replaces LocaleDateTimeContext uses DateTimeSymbols

- https://github.com/mP1/walkingkooka-datetime/pull/76
- BasicDateTimeContext replaces LocaleDateTimeContext uses DateTimeSymbols