### PR TITLE
ConverterPredicatedMapper.canConvert null test removed

### DIFF
--- a/src/main/java/walkingkooka/convert/ConverterPredicatedMapper.java
+++ b/src/main/java/walkingkooka/convert/ConverterPredicatedMapper.java
@@ -53,7 +53,7 @@ final class ConverterPredicatedMapper<S, D, C extends ConverterContext> implemen
     public boolean canConvert(final Object value,
                               final Class<?> type,
                               final C context) {
-        return (value == null || this.source.test(value)) &&
+        return this.source.test(value) &&
             this.target.test(type);
     }
 

--- a/src/test/java/walkingkooka/convert/ConverterCollectionTest.java
+++ b/src/test/java/walkingkooka/convert/ConverterCollectionTest.java
@@ -58,10 +58,10 @@ public final class ConverterCollectionTest extends ConverterTestCase2<ConverterC
     }
 
     @Test
-    public void testConvertNull() {
-        this.convertAndCheck(
+    public void testConvertNullToBooleanFails() {
+        this.convertFails(
             null,
-            false
+            Boolean.class
         );
     }
 

--- a/src/test/java/walkingkooka/convert/ConverterPredicatedMapperTest.java
+++ b/src/test/java/walkingkooka/convert/ConverterPredicatedMapperTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class ConverterPredicatedMapperTest extends ConverterTestCase2<ConverterPredicatedMapper<String, Boolean, ConverterContext>> {
 
-    private final static Predicate<Object> SOURCE = (t) -> t instanceof String;
+    private final static Predicate<Object> SOURCE = (t) -> null == t || t instanceof String;
     private final static Predicate<Class<?>> TARGET = Predicate.isEqual(Boolean.class);
     private final static Function<String, Boolean> MAPPER = Boolean::valueOf;
 
@@ -70,10 +70,19 @@ public final class ConverterPredicatedMapperTest extends ConverterTestCase2<Conv
     // converter........................................................................................................
 
     @Test
-    public void testConvertNull() {
+    public void testConvertNullToNonBoolean() {
+        this.convertFails(
+            null,
+            Void.class
+        );
+    }
+
+    @Test
+    public void testConvertNullToBoolean() {
         this.convertAndCheck(
             null,
-            false
+            Boolean.class,
+            false// Boolean.valueOf(null) -> false
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-convert/issues/233
- PredicatedMapperConverter#canConvert remove null test