### PR TITLE
BasicConverterContext: CurrencyLocaleContext was CanCurrencyForLocale…

### DIFF
--- a/src/main/java/walkingkooka/convert/BasicConverterContext.java
+++ b/src/main/java/walkingkooka/convert/BasicConverterContext.java
@@ -18,11 +18,10 @@
 package walkingkooka.convert;
 
 import walkingkooka.Either;
-import walkingkooka.currency.CanCurrencyForLocale;
+import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.datetime.DateTimeContext;
 import walkingkooka.datetime.DateTimeContextDelegator;
 import walkingkooka.datetime.DateTimeSymbols;
-import walkingkooka.locale.LocaleContext;
 import walkingkooka.math.DecimalNumberContext;
 import walkingkooka.math.DecimalNumberContextDelegator;
 import walkingkooka.math.DecimalNumberSymbols;
@@ -45,54 +44,48 @@ final class BasicConverterContext implements ConverterContext,
     /**
      * Creates a new {@link BasicConverterContext}.
      */
-    static BasicConverterContext with(final CanCurrencyForLocale canCurrencyForLocale,
-                                      final boolean canNumbersHaveGroupSeparator,
+    static BasicConverterContext with(final boolean canNumbersHaveGroupSeparator,
                                       final long dateOffset,
                                       final Indentation indentation,
                                       final LineEnding lineEnding,
                                       final char valueSeparator,
                                       final Converter<ConverterContext> converter,
+                                      final CurrencyLocaleContext currencyLocaleContext,
                                       final DateTimeContext dateTimeContext,
-                                      final DecimalNumberContext decimalNumberContext,
-                                      final LocaleContext localeContext) {
-        Objects.requireNonNull(canCurrencyForLocale, "canCurrencyForLocale");
+                                      final DecimalNumberContext decimalNumberContext) {
         Objects.requireNonNull(indentation, "indentation");
         Objects.requireNonNull(lineEnding, "lineEnding");
         Objects.requireNonNull(converter, "converter");
+        Objects.requireNonNull(currencyLocaleContext, "currencyLocaleContext");
         Objects.requireNonNull(dateTimeContext, "dateTimeContext");
         Objects.requireNonNull(decimalNumberContext, "decimalNumberContext");
-        Objects.requireNonNull(localeContext, "localeContext");
 
         return new BasicConverterContext(
-            canCurrencyForLocale,
             canNumbersHaveGroupSeparator,
             dateOffset,
             indentation,
             lineEnding,
             valueSeparator,
             converter,
+            currencyLocaleContext,
             dateTimeContext,
-            decimalNumberContext,
-            localeContext
+            decimalNumberContext
         );
     }
 
     /**
      * Private ctor use factory
      */
-    private BasicConverterContext(final CanCurrencyForLocale canCurrencyForLocale,
-                                  final boolean canNumbersHaveGroupSeparator,
+    private BasicConverterContext(final boolean canNumbersHaveGroupSeparator,
                                   final long dateOffset,
                                   final Indentation indentation,
                                   final LineEnding lineEnding,
                                   final char valueSeparator,
                                   final Converter<ConverterContext> converter,
+                                  final CurrencyLocaleContext currencyLocaleContext,
                                   final DateTimeContext dateTimeContext,
-                                  final DecimalNumberContext decimalNumberContext,
-                                  final LocaleContext localeContext) {
+                                  final DecimalNumberContext decimalNumberContext) {
         super();
-
-        this.canCurrencyForLocale = canCurrencyForLocale;
 
         this.canNumbersHaveGroupSeparator = canNumbersHaveGroupSeparator;
 
@@ -102,17 +95,11 @@ final class BasicConverterContext implements ConverterContext,
         this.valueSeparator = valueSeparator;
 
         this.converter = converter;
+
+        this.currencyLocaleContext = currencyLocaleContext;
         this.dateTimeContext = dateTimeContext;
         this.decimalNumberContext = decimalNumberContext;
-        this.localeContext = localeContext;
     }
-
-    @Override
-    public Optional<Currency> currencyForLocale(final Locale locale) {
-        return this.canCurrencyForLocale.currencyForLocale(locale);
-    }
-
-    private final CanCurrencyForLocale canCurrencyForLocale;
 
     @Override
     public boolean canNumbersHaveGroupSeparator() {
@@ -191,28 +178,35 @@ final class BasicConverterContext implements ConverterContext,
 
     private final DecimalNumberContext decimalNumberContext;
 
+    // CanCurrencyForLocale.............................................................................................
+
+    @Override
+    public Optional<Currency> currencyForLocale(final Locale locale) {
+        return this.currencyLocaleContext.currencyForLocale(locale);
+    }
+
     // CanDateTimeSymbolsForLocale......................................................................................
 
     @Override
     public Optional<DateTimeSymbols> dateTimeSymbolsForLocale(final Locale locale) {
-        return this.localeContext.dateTimeSymbolsForLocale(locale);
+        return this.currencyLocaleContext.dateTimeSymbolsForLocale(locale);
     }
 
     // CanDecimalNumberSymbolsForLocale.................................................................................
 
     @Override
     public Optional<DecimalNumberSymbols> decimalNumberSymbolsForLocale(final Locale locale) {
-        return this.localeContext.decimalNumberSymbolsForLocale(locale);
+        return this.currencyLocaleContext.decimalNumberSymbolsForLocale(locale);
     }
 
     // CanLocaleForLanguageTag..........................................................................................
 
     @Override
     public Optional<Locale> localeForLanguageTag(final String languageTag) {
-        return this.localeContext.localeForLanguageTag(languageTag);
+        return this.currencyLocaleContext.localeForLanguageTag(languageTag);
     }
 
-    private final LocaleContext localeContext;
+    private final CurrencyLocaleContext currencyLocaleContext;
 
     @Override
     public String toString() {

--- a/src/main/java/walkingkooka/convert/ConverterContexts.java
+++ b/src/main/java/walkingkooka/convert/ConverterContexts.java
@@ -17,9 +17,8 @@
 
 package walkingkooka.convert;
 
-import walkingkooka.currency.CanCurrencyForLocale;
+import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.datetime.DateTimeContext;
-import walkingkooka.locale.LocaleContext;
 import walkingkooka.math.DecimalNumberContext;
 import walkingkooka.reflect.PublicStaticHelper;
 import walkingkooka.text.Indentation;
@@ -33,27 +32,25 @@ public final class ConverterContexts implements PublicStaticHelper {
     /**
      * {@see BasicConverterContext}
      */
-    public static ConverterContext basic(final CanCurrencyForLocale canCurrencyForLocale,
-                                         final boolean canNumbersHaveGroupSeparator,
+    public static ConverterContext basic(final boolean canNumbersHaveGroupSeparator,
                                          final long dateOffset,
                                          final Indentation indentation,
                                          final LineEnding lineEnding,
                                          final char valueSeparator,
                                          final Converter<ConverterContext> converter,
+                                         final CurrencyLocaleContext currencyLocaleContext,
                                          final DateTimeContext dateTimeContext,
-                                         final DecimalNumberContext decimalNumberContext,
-                                         final LocaleContext localeContext) {
+                                         final DecimalNumberContext decimalNumberContext) {
         return BasicConverterContext.with(
-            canCurrencyForLocale,
             canNumbersHaveGroupSeparator,
             dateOffset,
             indentation,
             lineEnding,
             valueSeparator,
             converter,
+            currencyLocaleContext,
             dateTimeContext,
-            decimalNumberContext,
-            localeContext
+            decimalNumberContext
         );
     }
 

--- a/src/test/java/walkingkooka/convert/BasicConverterContextTest.java
+++ b/src/test/java/walkingkooka/convert/BasicConverterContextTest.java
@@ -18,11 +18,11 @@
 package walkingkooka.convert;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.currency.CanCurrencyForLocale;
+import walkingkooka.currency.CurrencyLocaleContext;
+import walkingkooka.currency.FakeCurrencyContext;
 import walkingkooka.datetime.DateTimeContext;
 import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.datetime.DateTimeSymbols;
-import walkingkooka.locale.LocaleContext;
 import walkingkooka.locale.LocaleContexts;
 import walkingkooka.math.DecimalNumberContext;
 import walkingkooka.math.DecimalNumberContextDelegator;
@@ -47,14 +47,6 @@ public final class BasicConverterContextTest implements ClassTesting2<BasicConve
     ConverterContextTesting<BasicConverterContext>,
     DecimalNumberContextDelegator {
 
-    private final static CanCurrencyForLocale CAN_CURRENCY_FOR_LOCALE = (locale) -> {
-        Objects.requireNonNull(locale, "locale");
-
-        return Optional.of(
-            Currency.getInstance(locale)
-        );
-    };
-
     private final static boolean CAN_NUMBERS_HAVE_GROUP_SEPARATOR = false;
     private final static long NUMBER_TO_DATE_OFFSET = 0;
     private final static char VALUE_SEPARATOR = ',';
@@ -78,44 +70,37 @@ public final class BasicConverterContextTest implements ClassTesting2<BasicConve
     private final static LineEnding LINE_ENDING = LineEnding.NL;
     private final static Locale LOCALE = Locale.ENGLISH;
 
-    private final static LocaleContext LOCALE_CONTEXT = LocaleContexts.jre(LOCALE);
+    private final static CurrencyLocaleContext CURRENCY_LOCALE_CONTEXT = new FakeCurrencyContext() {
+
+        @Override
+        public Optional<Currency> currencyForLocale(final Locale locale) {
+            Objects.requireNonNull(locale, "locale");
+
+            return Optional.of(
+                Currency.getInstance(locale)
+            );
+        }
+    }.setLocaleContext(
+        LocaleContexts.jre(LOCALE)
+    );
 
     private final static MathContext MATH_CONTEXT = MathContext.DECIMAL32;
 
-    @Test
-    public void testWithNullCanCurrencyForLocaleFails() {
-        assertThrows(
-            NullPointerException.class,
-            () -> BasicConverterContext.with(
-                null,
-                CAN_NUMBERS_HAVE_GROUP_SEPARATOR,
-                NUMBER_TO_DATE_OFFSET,
-                INDENTATION,
-                LINE_ENDING,
-                VALUE_SEPARATOR,
-                CONVERTER,
-                this.dateTimeContext(),
-                this.decimalNumberContext(),
-                LOCALE_CONTEXT
-            )
-        );
-    }
 
     @Test
     public void testWithNullIndentationFails() {
         assertThrows(
             NullPointerException.class,
             () -> BasicConverterContext.with(
-                CAN_CURRENCY_FOR_LOCALE,
                 CAN_NUMBERS_HAVE_GROUP_SEPARATOR,
                 NUMBER_TO_DATE_OFFSET,
                 null,
                 LINE_ENDING,
                 VALUE_SEPARATOR,
                 CONVERTER,
+                CURRENCY_LOCALE_CONTEXT,
                 this.dateTimeContext(),
-                this.decimalNumberContext(),
-                LOCALE_CONTEXT
+                this.decimalNumberContext()
             )
         );
     }
@@ -125,16 +110,15 @@ public final class BasicConverterContextTest implements ClassTesting2<BasicConve
         assertThrows(
             NullPointerException.class,
             () -> BasicConverterContext.with(
-                CAN_CURRENCY_FOR_LOCALE,
                 CAN_NUMBERS_HAVE_GROUP_SEPARATOR,
                 NUMBER_TO_DATE_OFFSET,
                 INDENTATION,
                 null,
                 VALUE_SEPARATOR,
                 CONVERTER,
+                CURRENCY_LOCALE_CONTEXT,
                 this.dateTimeContext(),
-                this.decimalNumberContext(),
-                LOCALE_CONTEXT
+                this.decimalNumberContext()
             )
         );
     }
@@ -144,26 +128,24 @@ public final class BasicConverterContextTest implements ClassTesting2<BasicConve
         assertThrows(
             NullPointerException.class,
             () -> BasicConverterContext.with(
-                CAN_CURRENCY_FOR_LOCALE,
                 CAN_NUMBERS_HAVE_GROUP_SEPARATOR,
                 NUMBER_TO_DATE_OFFSET,
                 INDENTATION,
                 LINE_ENDING,
                 VALUE_SEPARATOR,
                 null,
+                CURRENCY_LOCALE_CONTEXT,
                 this.dateTimeContext(),
-                this.decimalNumberContext(),
-                LOCALE_CONTEXT
+                this.decimalNumberContext()
             )
         );
     }
 
     @Test
-    public void testWithNullDateTimeContextFails() {
+    public void testWithNullCurrencyLocaleContextFails() {
         assertThrows(
             NullPointerException.class,
             () -> BasicConverterContext.with(
-                CAN_CURRENCY_FOR_LOCALE,
                 CAN_NUMBERS_HAVE_GROUP_SEPARATOR,
                 NUMBER_TO_DATE_OFFSET,
                 INDENTATION,
@@ -171,8 +153,27 @@ public final class BasicConverterContextTest implements ClassTesting2<BasicConve
                 VALUE_SEPARATOR,
                 CONVERTER,
                 null,
-                this.decimalNumberContext(),
-                LOCALE_CONTEXT
+                this.dateTimeContext(),
+                this.decimalNumberContext()
+            )
+        );
+    }
+
+
+    @Test
+    public void testWithNullDateTimeContextFails() {
+        assertThrows(
+            NullPointerException.class,
+            () -> BasicConverterContext.with(
+                CAN_NUMBERS_HAVE_GROUP_SEPARATOR,
+                NUMBER_TO_DATE_OFFSET,
+                INDENTATION,
+                LINE_ENDING,
+                VALUE_SEPARATOR,
+                CONVERTER,
+                CURRENCY_LOCALE_CONTEXT,
+                null,
+                this.decimalNumberContext()
             )
         );
     }
@@ -182,34 +183,14 @@ public final class BasicConverterContextTest implements ClassTesting2<BasicConve
         assertThrows(
             NullPointerException.class,
             () -> BasicConverterContext.with(
-                CAN_CURRENCY_FOR_LOCALE,
                 CAN_NUMBERS_HAVE_GROUP_SEPARATOR,
                 NUMBER_TO_DATE_OFFSET,
                 INDENTATION,
                 LINE_ENDING,
                 VALUE_SEPARATOR,
                 CONVERTER,
+                CURRENCY_LOCALE_CONTEXT,
                 this.dateTimeContext(),
-                null,
-                LOCALE_CONTEXT
-            )
-        );
-    }
-
-    @Test
-    public void testWithNullLocaleContextFails() {
-        assertThrows(
-            NullPointerException.class,
-            () -> BasicConverterContext.with(
-                CAN_CURRENCY_FOR_LOCALE,
-                CAN_NUMBERS_HAVE_GROUP_SEPARATOR,
-                NUMBER_TO_DATE_OFFSET,
-                INDENTATION,
-                LINE_ENDING,
-                VALUE_SEPARATOR,
-                CONVERTER,
-                this.dateTimeContext(),
-                this.decimalNumberContext(),
                 null
             )
         );
@@ -239,16 +220,15 @@ public final class BasicConverterContextTest implements ClassTesting2<BasicConve
     @Override
     public BasicConverterContext createContext() {
         return BasicConverterContext.with(
-            CAN_CURRENCY_FOR_LOCALE,
             CAN_NUMBERS_HAVE_GROUP_SEPARATOR,
             NUMBER_TO_DATE_OFFSET,
             INDENTATION,
             LINE_ENDING,
             VALUE_SEPARATOR,
             CONVERTER,
+            CURRENCY_LOCALE_CONTEXT,
             this.dateTimeContext(),
-            decimalNumberContext(),
-            LOCALE_CONTEXT
+            decimalNumberContext()
         );
     }
 

--- a/src/test/java/walkingkooka/convert/ConverterCharacterOrCharSequenceOrHasTextOrStringToCharacterOrCharSequenceOrStringTest.java
+++ b/src/test/java/walkingkooka/convert/ConverterCharacterOrCharSequenceOrHasTextOrStringToCharacterOrCharSequenceOrStringTest.java
@@ -19,6 +19,7 @@ package walkingkooka.convert;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
+import walkingkooka.currency.FakeCurrencyContext;
 import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.locale.LocaleContexts;
 import walkingkooka.math.DecimalNumberContexts;
@@ -34,6 +35,7 @@ import java.math.MathContext;
 import java.text.DecimalFormat;
 import java.util.Currency;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 
 public final class ConverterCharacterOrCharSequenceOrHasTextOrStringToCharacterOrCharSequenceOrStringTest extends ConverterTestCase2<ConverterCharacterOrCharSequenceOrHasTextOrStringToCharacterOrCharSequenceOrString<ConverterContext>> {
@@ -426,20 +428,29 @@ public final class ConverterCharacterOrCharSequenceOrHasTextOrStringToCharacterO
             BigDecimal.valueOf(5),
             Character.class,
             ConverterContexts.basic(
-                (l) -> Optional.of(
-                    Currency.getInstance(l)
-                ), // canCurrencyForLocale
                 false, // canNumbersHaveGroupSeparator
                 0, // dateTimeOffset
                 Indentation.SPACES2,
                 LineEnding.NL,
                 ',', // valueSeparator
                 Converters.fake(),
+                new FakeCurrencyContext() {
+
+                    @Override
+                    public Optional<Currency> currencyForLocale(final Locale locale) {
+                        Objects.requireNonNull(locale, "locale");
+
+                        return Optional.of(
+                            Currency.getInstance(locale)
+                        );
+                    }
+                }.setLocaleContext(
+                    LocaleContexts.jre(
+                        Locale.forLanguageTag("en-AU")
+                    )
+                ),
                 DateTimeContexts.fake(),
-                DecimalNumberContexts.american(MathContext.DECIMAL32),
-                LocaleContexts.jre(
-                    Locale.forLanguageTag("en-AU")
-                )
+                DecimalNumberContexts.american(MathContext.DECIMAL32)
             ),
             '5'
         );

--- a/src/test/java/walkingkooka/convert/ConverterCharacterOrStringToStringTest.java
+++ b/src/test/java/walkingkooka/convert/ConverterCharacterOrStringToStringTest.java
@@ -19,6 +19,7 @@ package walkingkooka.convert;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
+import walkingkooka.currency.FakeCurrencyContext;
 import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.locale.LocaleContexts;
 import walkingkooka.math.DecimalNumberContexts;
@@ -113,20 +114,26 @@ public final class ConverterCharacterOrStringToStringTest implements ConverterTe
             '5',
             Number.class,
             ConverterContexts.basic(
-                (l) -> Optional.of(
-                    Currency.getInstance(l)
-                ), // canCurrencyForLocale
                 false, // canNumbersHaveGroupSeparator
                 0, // dateOffset
                 Indentation.SPACES2,
                 LineEnding.NL,
                 ',', // valueSeparator
                 Converters.fake(),
+                new FakeCurrencyContext() {
+                    @Override
+                    public Optional<Currency> currencyForLocale(final Locale locale) {
+                        return Optional.of(
+                            Currency.getInstance(locale)
+                        );
+                    }
+                }.setLocaleContext(
+                    LocaleContexts.jre(
+                        Locale.forLanguageTag("en-AU")
+                    )
+                ),
                 DateTimeContexts.fake(),
-                DecimalNumberContexts.american(MathContext.DECIMAL32),
-                LocaleContexts.jre(
-                    Locale.forLanguageTag("en-AU")
-                )
+                DecimalNumberContexts.american(MathContext.DECIMAL32)
             ),
             BigDecimal.valueOf(5)
         );

--- a/src/test/java/walkingkooka/convert/ConverterContextDelegatorTest.java
+++ b/src/test/java/walkingkooka/convert/ConverterContextDelegatorTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.convert;
 
 import walkingkooka.convert.ConverterContextDelegatorTest.TestConverterContextDelegator;
+import walkingkooka.currency.FakeCurrencyContext;
 import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.datetime.DateTimeSymbols;
 import walkingkooka.locale.LocaleContexts;
@@ -30,8 +31,10 @@ import walkingkooka.text.LineEnding;
 import java.math.MathContext;
 import java.text.DateFormatSymbols;
 import java.time.LocalDateTime;
+import java.util.Currency;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Optional;
 
 public final class ConverterContextDelegatorTest implements ConverterContextTesting<TestConverterContextDelegator>,
     DecimalNumberContextDelegator {
@@ -76,16 +79,23 @@ public final class ConverterContextDelegatorTest implements ConverterContextTest
             final Locale locale = Locale.ENGLISH;
 
             return ConverterContexts.basic(
-                (l) -> {
-                    Objects.requireNonNull(l, "locale");
-                    throw new UnsupportedOperationException();
-                }, // canCurrencyForLocale
                 false, // canNumbersHaveGroupSeparator
                 0, // dateTimeOffset
                 Indentation.SPACES2,
                 LineEnding.NL,
                 ',', // valueSeparator
                 Converters.fake(),
+                new FakeCurrencyContext() {
+                    @Override
+                    public Optional<Currency> currencyForLocale(final Locale locale) {
+                        Objects.requireNonNull(locale, "locale");
+                        return Optional.of(
+                            Currency.getInstance(locale)
+                        );
+                    }
+                }.setLocaleContext(
+                    LocaleContexts.jre(locale)
+                ),
                 DateTimeContexts.basic(
                     DateTimeSymbols.fromDateFormatSymbols(
                         new DateFormatSymbols(locale)
@@ -95,8 +105,7 @@ public final class ConverterContextDelegatorTest implements ConverterContextTest
                     50,
                     LocalDateTime::now
                 ),
-                DecimalNumberContexts.american(MathContext.DECIMAL32),
-                LocaleContexts.jre(locale)
+                DecimalNumberContexts.american(MathContext.DECIMAL32)
             );
         }
 

--- a/src/test/java/walkingkooka/convert/ConverterDecimalFormatTestCase.java
+++ b/src/test/java/walkingkooka/convert/ConverterDecimalFormatTestCase.java
@@ -19,6 +19,7 @@ package walkingkooka.convert;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
+import walkingkooka.currency.FakeCurrencyContext;
 import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.locale.LocaleContexts;
 import walkingkooka.math.DecimalNumberContext;
@@ -78,15 +79,22 @@ public abstract class ConverterDecimalFormatTestCase<C extends ConverterDecimalF
 
     final ConverterContext createContext(final Locale locale) {
         return ConverterContexts.basic(
-            (l) -> Optional.of(
-                Currency.getInstance(l)
-            ), // canCurrencyForLocale
             false, // canNumbersHaveGroupSeparator
             0, // dateOffset
             Indentation.SPACES2,
             LineEnding.NL,
             ',', // valueSeparator
             Converters.fake(),
+            new FakeCurrencyContext() {
+                @Override
+                public Optional<Currency> currencyForLocale(final Locale locale) {
+                    return Optional.of(
+                        Currency.getInstance(locale)
+                    );
+                }
+            }.setLocaleContext(
+                LocaleContexts.jre(locale)
+            ),
             DateTimeContexts.fake(),
             DecimalNumberContexts.basic(
                 DecimalNumberContext.DEFAULT_NUMBER_DIGIT_COUNT,
@@ -96,8 +104,7 @@ public abstract class ConverterDecimalFormatTestCase<C extends ConverterDecimalF
                 ),
                 locale,
                 MathContext.DECIMAL32
-            ),
-            LocaleContexts.jre(locale)
+            )
         );
     }
 

--- a/src/test/java/walkingkooka/convert/ConverterLikeDelegatorTest.java
+++ b/src/test/java/walkingkooka/convert/ConverterLikeDelegatorTest.java
@@ -19,9 +19,9 @@ package walkingkooka.convert;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.convert.ConverterLikeDelegatorTest.TestConverterLikeDelegator;
+import walkingkooka.currency.CurrencyLocaleContexts;
 import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.datetime.DateTimeSymbols;
-import walkingkooka.locale.LocaleContexts;
 import walkingkooka.math.DecimalNumberContexts;
 import walkingkooka.text.Indentation;
 import walkingkooka.text.LineEnding;
@@ -59,9 +59,6 @@ public final class ConverterLikeDelegatorTest implements ConverterLikeTesting<Te
             final Locale locale = Locale.forLanguageTag("EN-AU");
 
             return ConverterContexts.basic(
-                (l) -> {
-                    throw new UnsupportedOperationException();
-                }, // canCurrencyForLocale
                 false, // canNumbersHaveGroupSeparator
                 Converters.EXCEL_1900_DATE_SYSTEM_OFFSET,
                 Indentation.SPACES2,
@@ -70,6 +67,7 @@ public final class ConverterLikeDelegatorTest implements ConverterLikeTesting<Te
                 Converters.stringToLocalDate(
                     (x) -> DateTimeFormatter.ofPattern("yyyy MM dd")
                 ),
+                CurrencyLocaleContexts.fake(),
                 DateTimeContexts.basic(
                     DateTimeSymbols.fromDateFormatSymbols(
                         new DateFormatSymbols(locale)
@@ -79,8 +77,7 @@ public final class ConverterLikeDelegatorTest implements ConverterLikeTesting<Te
                     50, // twoDigitYear
                     LocalDateTime::now
                 ),
-                DecimalNumberContexts.american(MathContext.DECIMAL32),
-                LocaleContexts.jre(locale)
+                DecimalNumberContexts.american(MathContext.DECIMAL32)
             );
         }
     }

--- a/src/test/java/walkingkooka/convert/ConverterLocaleToLocaleTest.java
+++ b/src/test/java/walkingkooka/convert/ConverterLocaleToLocaleTest.java
@@ -19,6 +19,7 @@ package walkingkooka.convert;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
+import walkingkooka.currency.CurrencyContexts;
 import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.locale.LocaleContexts;
 import walkingkooka.math.DecimalNumberContexts;
@@ -95,20 +96,20 @@ public final class ConverterLocaleToLocaleTest extends ConverterLocaleToTestCase
     @Override
     public ConverterContext createContext() {
         return ConverterContexts.basic(
-            (l) -> {
-                throw new UnsupportedOperationException();
-            }, // canCurrencyForLocale
             false, // canNumbersHaveGroupSeparator
             Converters.EXCEL_1904_DATE_SYSTEM_OFFSET,
             Indentation.SPACES2,
             LineEnding.NL,
             ',', // valueSeparator
             Converters.characterOrCharSequenceOrHasTextOrStringToCharacterOrCharSequenceOrString(),
+            CurrencyContexts.fake()
+                .setLocaleContext(
+                    LocaleContexts.jre(
+                        Locale.forLanguageTag("en-AU")
+                    )
+                ),
             DateTimeContexts.fake(),
-            DecimalNumberContexts.fake(),
-            LocaleContexts.jre(
-                Locale.forLanguageTag("en-AU")
-            )
+            DecimalNumberContexts.fake()
         );
     }
 

--- a/src/test/java/walkingkooka/convert/ConverterParserTest.java
+++ b/src/test/java/walkingkooka/convert/ConverterParserTest.java
@@ -20,8 +20,8 @@ package walkingkooka.convert;
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
 import walkingkooka.HashCodeEqualsDefinedTesting2;
+import walkingkooka.currency.CurrencyLocaleContexts;
 import walkingkooka.datetime.DateTimeContexts;
-import walkingkooka.locale.LocaleContexts;
 import walkingkooka.math.DecimalNumberContexts;
 import walkingkooka.text.Indentation;
 import walkingkooka.text.LineEnding;
@@ -164,18 +164,15 @@ public final class ConverterParserTest extends ConverterTestCase2<ConverterParse
     @Override
     public ConverterContext createContext() {
         return ConverterContexts.basic(
-            (l) -> {
-                throw new UnsupportedOperationException();
-            }, // canCurrencyForLocale
             false, // canNumbersHaveGroupSeparator
             0, // dateOffset
             Indentation.SPACES2,
             LineEnding.NL,
             ',', // valueSeparator
             Converters.characterOrCharSequenceOrHasTextOrStringToCharacterOrCharSequenceOrString(),
+            CurrencyLocaleContexts.fake(),
             DateTimeContexts.fake(),
-            DecimalNumberContexts.american(MathContext.DECIMAL32),
-            LocaleContexts.fake()
+            DecimalNumberContexts.american(MathContext.DECIMAL32)
         );
     }
 

--- a/src/test/java/walkingkooka/convert/ConverterStringToCharacterOrStringTest.java
+++ b/src/test/java/walkingkooka/convert/ConverterStringToCharacterOrStringTest.java
@@ -19,6 +19,7 @@ package walkingkooka.convert;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
+import walkingkooka.currency.FakeCurrencyContext;
 import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.locale.LocaleContexts;
 import walkingkooka.math.DecimalNumberContexts;
@@ -125,18 +126,26 @@ public final class ConverterStringToCharacterOrStringTest implements ConverterTe
             BigDecimal.valueOf(5),
             Character.class,
             ConverterContexts.basic(
-                (l) -> Optional.of(
-                    Currency.getInstance(l)
-                ), // canCurrencyForLocale
                 false, // canNumbersHaveGroupSeparator
                 0, // dateTimeOffset
                 Indentation.SPACES2,
                 LineEnding.NL,
                 ',', // valueSeparator
                 Converters.fake(),
+                new FakeCurrencyContext() {
+                    @Override
+                    public Optional<Currency> currencyForLocale(final Locale locale) {
+                        return Optional.of(
+                            Currency.getInstance(locale)
+                        );
+                    }
+                }.setLocaleContext(
+                    LocaleContexts.jre(
+                        Locale.forLanguageTag("en-AU")
+                    )
+                ),
                 DateTimeContexts.fake(),
-                DecimalNumberContexts.american(MathContext.DECIMAL32),
-                LocaleContexts.fake()
+                DecimalNumberContexts.american(MathContext.DECIMAL32)
             ),
             '5'
         );


### PR DESCRIPTION
… & LocaleContext

- Closes https://github.com/mP1/walkingkooka-convert/issues/422
- BasicConverterContext CurrencyLocaleContext replaces CanCurrencyForLocale and LocaleContext