### PR TITLE
ConverterTextToCollectionXXXCsvStringXXX & ConverterTextToCollectionX…

### DIFF
--- a/src/main/java/walkingkooka/convert/ConverterTextToCollection.java
+++ b/src/main/java/walkingkooka/convert/ConverterTextToCollection.java
@@ -31,10 +31,9 @@ abstract class ConverterTextToCollection<IMMUTABLE_COLLECTION extends Collection
         super();
     }
 
-    @Override
-    public final Object parseText(final String text,
-                                  final Class<?> type,
-                                  final CONTEXT context) {
+    final Object parseTextWithValueSeparator(final String text,
+                                             final Class<?> type,
+                                             final CONTEXT context) {
         final int MODE_OUTSIDE_QUOTES = 1;
         final int MODE_INSIDE_QUOTES = 2;
         final int MODE_INSIDE_QUOTES_ESCAPE_NEXT = 3;

--- a/src/main/java/walkingkooka/convert/ConverterTextToCollectionListBooleanList.java
+++ b/src/main/java/walkingkooka/convert/ConverterTextToCollectionListBooleanList.java
@@ -52,6 +52,17 @@ final class ConverterTextToCollectionListBooleanList<C extends ConverterContext>
     }
 
     @Override
+    public Object parseText(final String text,
+                            final Class<?> type,
+                            final C context) {
+        return this.parseTextWithValueSeparator(
+            text,
+            type,
+            context
+        );
+    }
+
+    @Override
     Class<BooleanList> targetType() {
         return BooleanList.class;
     }

--- a/src/main/java/walkingkooka/convert/ConverterTextToCollectionListCsvStringList.java
+++ b/src/main/java/walkingkooka/convert/ConverterTextToCollectionListCsvStringList.java
@@ -49,12 +49,19 @@ final class ConverterTextToCollectionListCsvStringList<C extends ConverterContex
     }
 
     @Override
+    public Object parseText(final String text,
+                            final Class<?> type,
+                            final C context) {
+        return CsvStringList.parse(text);
+    }
+
+    @Override
     Class<String> elementType() {
-        return String.class;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     CsvStringList toImmutableCollection(final List<String> mutableCollection) {
-        return CsvStringList.EMPTY.setElements(mutableCollection);
+        throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/walkingkooka/convert/ConverterTextToCollectionListLocalDateList.java
+++ b/src/main/java/walkingkooka/convert/ConverterTextToCollectionListLocalDateList.java
@@ -58,6 +58,17 @@ final class ConverterTextToCollectionListLocalDateList<C extends ConverterContex
     }
 
     @Override
+    public Object parseText(final String text,
+                            final Class<?> type,
+                            final C context) {
+        return this.parseTextWithValueSeparator(
+            text,
+            type,
+            context
+        );
+    }
+
+    @Override
     Class<LocalDate> elementType() {
         return LocalDate.class;
     }

--- a/src/main/java/walkingkooka/convert/ConverterTextToCollectionListLocalDateTimeList.java
+++ b/src/main/java/walkingkooka/convert/ConverterTextToCollectionListLocalDateTimeList.java
@@ -58,6 +58,17 @@ final class ConverterTextToCollectionListLocalDateTimeList<C extends ConverterCo
     }
 
     @Override
+    public Object parseText(final String text,
+                            final Class<?> type,
+                            final C context) {
+        return this.parseTextWithValueSeparator(
+            text,
+            type,
+            context
+        );
+    }
+
+    @Override
     Class<LocalDateTime> elementType() {
         return LocalDateTime.class;
     }

--- a/src/main/java/walkingkooka/convert/ConverterTextToCollectionListLocalTimeList.java
+++ b/src/main/java/walkingkooka/convert/ConverterTextToCollectionListLocalTimeList.java
@@ -58,6 +58,17 @@ final class ConverterTextToCollectionListLocalTimeList<C extends ConverterContex
     }
 
     @Override
+    public Object parseText(final String text,
+                            final Class<?> type,
+                            final C context) {
+        return this.parseTextWithValueSeparator(
+            text,
+            type,
+            context
+        );
+    }
+
+    @Override
     Class<LocalTime> elementType() {
         return LocalTime.class;
     }

--- a/src/main/java/walkingkooka/convert/ConverterTextToCollectionListNumberList.java
+++ b/src/main/java/walkingkooka/convert/ConverterTextToCollectionListNumberList.java
@@ -57,6 +57,17 @@ final class ConverterTextToCollectionListNumberList<C extends ConverterContext> 
     }
 
     @Override
+    public Object parseText(final String text,
+                            final Class<?> type,
+                            final C context) {
+        return this.parseTextWithValueSeparator(
+            text,
+            type,
+            context
+        );
+    }
+
+    @Override
     Class<Number> elementType() {
         return Number.class;
     }

--- a/src/main/java/walkingkooka/convert/ConverterTextToCollectionListStringList.java
+++ b/src/main/java/walkingkooka/convert/ConverterTextToCollectionListStringList.java
@@ -58,6 +58,17 @@ final class ConverterTextToCollectionListStringList<C extends ConverterContext> 
     }
 
     @Override
+    public Object parseText(final String text,
+                            final Class<?> type,
+                            final C context) {
+        return this.parseTextWithValueSeparator(
+            text,
+            type,
+            context
+        );
+    }
+
+    @Override
     Class<String> elementType() {
         return String.class;
     }

--- a/src/main/java/walkingkooka/convert/ConverterTextToCollectionListTsvStringList.java
+++ b/src/main/java/walkingkooka/convert/ConverterTextToCollectionListTsvStringList.java
@@ -49,6 +49,13 @@ final class ConverterTextToCollectionListTsvStringList<C extends ConverterContex
     }
 
     @Override
+    public Object parseText(final String text,
+                            final Class<?> type,
+                            final C context) {
+        return TsvStringList.parse(text);
+    }
+
+    @Override
     Class<String> elementType() {
         return String.class;
     }

--- a/src/main/java/walkingkooka/convert/ConverterTextToCollectionSetCsvStringSet.java
+++ b/src/main/java/walkingkooka/convert/ConverterTextToCollectionSetCsvStringSet.java
@@ -49,12 +49,19 @@ final class ConverterTextToCollectionSetCsvStringSet<C extends ConverterContext>
     }
 
     @Override
+    public CsvStringSet parseText(final String text,
+                                  final Class<?> type,
+                                  final C context) {
+        return CsvStringSet.parse(text);
+    }
+
+    @Override
     Class<String> elementType() {
-        return String.class;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     CsvStringSet toImmutableCollection(final Set<String> mutableCollection) {
-        return CsvStringSet.EMPTY.setElements(mutableCollection);
+        throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/walkingkooka/convert/ConverterTextToCollectionSetCurrencyCodeSet.java
+++ b/src/main/java/walkingkooka/convert/ConverterTextToCollectionSetCurrencyCodeSet.java
@@ -50,6 +50,17 @@ final class ConverterTextToCollectionSetCurrencyCodeSet<C extends ConverterConte
     }
 
     @Override
+    public Object parseText(final String text,
+                            final Class<?> type,
+                            final C context) {
+        return this.parseTextWithValueSeparator(
+            text,
+            type,
+            context
+        );
+    }
+
+    @Override
     Class<CurrencyCode> elementType() {
         return CurrencyCode.class;
     }

--- a/src/main/java/walkingkooka/convert/ConverterTextToCollectionSetLocaleLanguageTagSet.java
+++ b/src/main/java/walkingkooka/convert/ConverterTextToCollectionSetLocaleLanguageTagSet.java
@@ -50,6 +50,17 @@ final class ConverterTextToCollectionSetLocaleLanguageTagSet<C extends Converter
     }
 
     @Override
+    public Object parseText(final String text,
+                            final Class<?> type,
+                            final C context) {
+        return this.parseTextWithValueSeparator(
+            text,
+            type,
+            context
+        );
+    }
+
+    @Override
     Class<LocaleLanguageTag> elementType() {
         return LocaleLanguageTag.class;
     }

--- a/src/main/java/walkingkooka/convert/ConverterTextToCollectionSetTsvStringSet.java
+++ b/src/main/java/walkingkooka/convert/ConverterTextToCollectionSetTsvStringSet.java
@@ -49,12 +49,19 @@ final class ConverterTextToCollectionSetTsvStringSet<C extends ConverterContext>
     }
 
     @Override
+    public TsvStringSet parseText(final String text,
+                                  final Class<?> type,
+                                  final C context) {
+        return TsvStringSet.parse(text);
+    }
+
+    @Override
     Class<String> elementType() {
-        return String.class;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     TsvStringSet toImmutableCollection(final Set<String> mutableCollection) {
-        return TsvStringSet.EMPTY.setElements(mutableCollection);
+        throw new UnsupportedOperationException();
     }
 }

--- a/src/test/java/walkingkooka/convert/ConverterTextToCollectionListCsvStringListTest.java
+++ b/src/test/java/walkingkooka/convert/ConverterTextToCollectionListCsvStringListTest.java
@@ -32,11 +32,9 @@ public final class ConverterTextToCollectionListCsvStringListTest extends Conver
     private final static char SEPARATOR = ',';
 
     @Test
-    public void testConvertEmptyStringFails() {
-        this.convertFails(
-            this.createConverter(),
-            "",
-            CsvStringList.class
+    public void testConvertEmptyString() {
+        this.convertToCollectionAndCheck(
+            ""
         );
     }
 
@@ -49,10 +47,10 @@ public final class ConverterTextToCollectionListCsvStringListTest extends Conver
     }
 
     @Test
-    public void testConvertStringSurroundingSpacesTrimmed() {
+    public void testConvertStringSurroundingSpaces() {
         this.convertToCollectionAndCheck(
             " " + STRING2 + " ",
-            STRING2
+            " " + STRING2 + " "
         );
     }
 
@@ -100,10 +98,10 @@ public final class ConverterTextToCollectionListCsvStringListTest extends Conver
     public ConverterContext createContext() {
         return new FakeConverterContext() {
 
-            @Override
-            public char valueSeparator() {
-                return SEPARATOR;
-            }
+//            @Override
+//            public char valueSeparator() {
+//                return SEPARATOR;
+//            }
 
             @Override
             public boolean canConvert(final Object value,

--- a/src/test/java/walkingkooka/convert/ConverterTextToCollectionListTsvStringListTest.java
+++ b/src/test/java/walkingkooka/convert/ConverterTextToCollectionListTsvStringListTest.java
@@ -40,14 +40,6 @@ public final class ConverterTextToCollectionListTsvStringListTest extends Conver
     }
 
     @Test
-    public void testConvertStringSurroundingSpacesTrimmed() {
-        this.convertToCollectionAndCheck(
-            " " + STRING2 + " ",
-            STRING2
-        );
-    }
-
-    @Test
     public void testConvertCharSequenceString() {
         this.convertToCollectionAndCheck(
             new StringBuilder(STRING),

--- a/src/test/java/walkingkooka/convert/ConverterTextToCollectionSetCsvStringSetTest.java
+++ b/src/test/java/walkingkooka/convert/ConverterTextToCollectionSetCsvStringSetTest.java
@@ -40,10 +40,10 @@ public final class ConverterTextToCollectionSetCsvStringSetTest extends Converte
     }
 
     @Test
-    public void testConvertStringSurroundingSpacesTrimmed() {
+    public void testConvertStringSurroundingSpaces() {
         this.convertToCollectionAndCheck(
             " " + STRING2 + " ",
-            STRING2
+            " " + STRING2 + " "
         );
     }
 

--- a/src/test/java/walkingkooka/convert/ConverterTextToCollectionSetTsvStringSetTest.java
+++ b/src/test/java/walkingkooka/convert/ConverterTextToCollectionSetTsvStringSetTest.java
@@ -40,10 +40,10 @@ public final class ConverterTextToCollectionSetTsvStringSetTest extends Converte
     }
 
     @Test
-    public void testConvertStringSurroundingSpacesTrimmed() {
+    public void testConvertStringSurroundingSpaces() {
         this.convertToCollectionAndCheck(
             " " + STRING2 + " ",
-            STRING2
+            " " + STRING2 + " "
         );
     }
 


### PR DESCRIPTION
…XXTsvStringXXX should not use Context#valueSeparator but Comma/Tab FIX

- Closes https://github.com/mP1/walkingkooka-convert/issues/554
- ConverterTextToCollectionXXXCsvStringXXX & ConverterTextToCollectionXXXTsvStringXXX should not use Context#valueSeparator but Comma/Tab